### PR TITLE
Fixed 00:00 remaining bug

### DIFF
--- a/Source/DiscordUE4/Private/DiscordObject.cpp
+++ b/Source/DiscordUE4/Private/DiscordObject.cpp
@@ -210,6 +210,9 @@ void UDiscordObject::SetJoinSecret(FString InNewJoinSecret)
 
 void UDiscordObject::StartDiscordTimer()
 {
+	// probably only needed in the editor, but this resets the time across multiple sessions, preventing 00:00 remaining from displaying.
+	activity.GetTimestamps().SetEnd(0);
+
 	activity.GetTimestamps().SetStart(FDateTime::UtcNow().ToUnixTimestamp());
 	if (core)
 	{


### PR DESCRIPTION
When launching PIE, the time stamp in discord works the first time, but upon closing and reopening PIE, discord only displays "00:00 remaining", until discord is closed and reopened. This PR fixes this bug by correctly resetting the end time whenever the timer starts.

Thanks for making this plugin BTW!